### PR TITLE
Remove signing note from claude-usage-tracker.rb

### DIFF
--- a/Casks/claude-usage-tracker.rb
+++ b/Casks/claude-usage-tracker.rb
@@ -25,9 +25,6 @@ cask "claude-usage-tracker" do
 
     On first launch, you'll be guided through setup to extract your session key.
 
-    Note: This app is not signed with an Apple Developer certificate.
-    You'll need to approve it in System Settings → Privacy & Security on first launch.
-
     For more information, visit: https://github.com/hamed-elfayome/Claude-Usage-Tracker
   EOS
 end


### PR DESCRIPTION
Removed note about app not being signed and approval process. It is signed now, has been since 2.0 (yay!!)

fixes #1 