### PR TITLE
fix(cask): correct zap paths for preferences and application support

### DIFF
--- a/Casks/claude-usage-tracker.rb
+++ b/Casks/claude-usage-tracker.rb
@@ -15,8 +15,8 @@ cask "claude-usage-tracker" do
   app "Claude Usage.app"
 
   zap trash: [
-    "~/Library/Preferences/com.hamed.Claude-Usage.plist",
-    "~/Library/Application Support/com.hamed.Claude-Usage",
+    "~/Library/Preferences/HamedElfayome.Claude-Usage.plist",
+    "~/Library/Application Support/Claude Usage",
     "~/.claude-session-key",
   ]
 


### PR DESCRIPTION
Two of the three `zap trash:` paths don't match what the app actually creates, so
`brew uninstall --zap claude-usage-tracker` leaves user data behind.

| `zap` entry | Actual path |
|---|---|
| `~/Library/Preferences/com.hamed.Claude-Usage.plist` | `~/Library/Preferences/HamedElfayome.Claude-Usage.plist` |
| `~/Library/Application Support/com.hamed.Claude-Usage` | `~/Library/Application Support/Claude Usage` |

## Evidence

- Bundle identifier is `HamedElfayome.Claude-Usage`, which determines the
  preferences filename:
  `Claude Usage.xcodeproj/project.pbxproj` → `PRODUCT_BUNDLE_IDENTIFIER = "HamedElfayome.Claude-Usage"`
- The Application Support subdirectory is `Claude Usage`:
  - `Shared/Services/UsageHistoryService.swift` → `.appendingPathComponent("Claude Usage", isDirectory: true)`
  - `Shared/Services/NetworkLoggerService.swift` → `appSupport.appendingPathComponent("Claude Usage")`

Verified on a real 3.2.0 install (macOS 15.7.5, Homebrew 6.0.11): neither `zap` path
exists, while both corrected paths do — the preferences plist holds `profiles_v3`
and the statusline settings, and `~/Library/Application Support/Claude Usage` is ~1.5 MB
of history and logs. Both survive `--zap` today.

`~/.claude-session-key` is left as-is: it's legacy after the migration to Keychain
in `KeychainMigrationService`, but old installs may still have the file.

## Notes (out of scope for this PR)

Two other things `--zap` currently leaves behind, happy to file separately:

- The statusline files installed by `StatuslineService` into `~/.claude/`:
  `statusline-command.sh`, `statusline-config.txt`, `fetch-claude-usage.swift`,
  `.statusline-usage-cache`. (The `statusLine` key it adds to `~/.claude/settings.json`
  can't be reverted by `zap` anyway.)
- The Keychain entry holding the session key — `zap` has no declarative
  directive for Keychain items.